### PR TITLE
Make sure world doesn't get dropped early.

### DIFF
--- a/ci/build-ompi.sh
+++ b/ci/build-ompi.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-if [ -d "$HOME/ompi" ]; then
+if [ -f "$HOME/ompi/bin/mpicc" ]; then
+  export PATH=$HOME/ompi/bin:$PATH
+  export LD_LIBRARY_PATH=$HOME/ompi/lib:$LD_LIBRARY_PATH
   echo "Openmpi already installed."
   exit 0
 fi

--- a/src/bin/multi_lat.rs
+++ b/src/bin/multi_lat.rs
@@ -2,7 +2,7 @@ extern crate mpi;
 extern crate num;
 
 use mpi::traits::*;
-use mpi::topology::Universe;
+use mpi::topology::{Universe, SystemCommunicator};
 use num::pow;
 use mpi::collective::SystemOperation;
 use std::process;
@@ -34,12 +34,12 @@ fn main() {
   }
 
   world.barrier();
-  multi_latency(rank, pairs, universe);
+  multi_latency(rank, pairs, universe, world);
   world.barrier();
 }
 
-fn multi_latency(rank: i32, pairs: i32, universe: Universe) {
-  let world = universe.world();
+fn multi_latency(rank: i32, pairs: i32,
+                 universe: Universe, world: SystemCommunicator) {
   let s_buf = vec![0;BUF_SIZE];
   let root_process = world.process_at_rank(0);
 

--- a/src/bin/multi_lat.rs
+++ b/src/bin/multi_lat.rs
@@ -34,12 +34,12 @@ fn main() {
   }
 
   world.barrier();
-  multi_latency(rank, pairs, universe, world);
+  multi_latency(rank, pairs, &universe, &world);
   world.barrier();
 }
 
 fn multi_latency(rank: i32, pairs: i32,
-                 universe: Universe, world: SystemCommunicator) {
+                 universe: &Universe, world: &SystemCommunicator) {
   let s_buf = vec![0;BUF_SIZE];
   let root_process = world.process_at_rank(0);
 


### PR DESCRIPTION
The copy of world made in multi_latency got dropped early,
which called MPI_Finalize.
Prevent travis from building openmpi on every build.
